### PR TITLE
updated Cargo file with changed piston-related dependency names and repo...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ path = "./src/snake.rs"
 
 git = "https://github.com/PistonDevelopers/piston"
 
-[dependencies.graphics]
+[dependencies.piston2d-graphics]
 
-git = "https://github.com/PistonDevelopers/rust-graphics"
+git = "https://github.com/PistonDevelopers/graphics"
 
-[dependencies.sdl2_game_window]
+[dependencies.pistoncore-sdl2_window]
 
 git = "https://github.com/PistonDevelopers/sdl2_game_window"
 
-[dependencies.opengl_graphics]
+[dependencies.piston2d-opengl_graphics]
 
 git = "https://github.com/PistonDevelopers/opengl_graphics"
 

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -1,18 +1,18 @@
-#![feature(globs, phase)]
+#![feature(globs)]
 
 extern crate collections;
-#[phase(plugin, link)] extern crate log;
+#[macro_use] extern crate log;
 extern crate graphics;
 extern crate piston;
 
-extern crate sdl2_game_window;
+extern crate sdl2_window;
 extern crate opengl_graphics;
 
 use std::rand::random;
 use graphics::*;
 use opengl_graphics::Gl;
 use piston::{Game, GameIteratorSettings, GameWindowSettings, KeyReleaseArgs, RenderArgs};
-use sdl2_game_window::GameWindowSDL2;
+use sdl2_window::GameWindowSDL2;
 
 pub static WINDOW_HEIGHT: uint = 480;
 pub static WINDOW_WIDTH: uint = 640;


### PR DESCRIPTION
...sitories.

Unfortunately, it doesn't yet compile as some other dependencies don't seem to compile with `rustc 1.0.0-dev`. Maybe I am not latest enough as I installed via brew, and didn't try the nightly binary installers yet.

For completeness, I am dropping the issues here - it's not related to snake.rs at all:

``` bash
Compiling gl_common v0.0.3 (https://github.com/bjz/gl-rs#a5be6727)
   Compiling current v0.0.5 (https://github.com/pistondevelopers/current#749a98a3)
   Compiling khronos_api v0.0.5 (https://github.com/bjz/gl-rs#a5be6727)
   Compiling piston-texture v0.0.1
   Compiling khronos_api v0.0.5
   Compiling shader_version v0.0.1 (https://github.com/pistondevelopers/shader_version#71300bf7)
   Compiling piston-texture v0.0.1 (https://github.com/PistonDevelopers/texture#0380876c)
   Compiling rustc-serialize v0.2.8
/Users/byron/.cargo/git/checkouts/current-4c0469929c5bbcc9/master/src/lib.rs:10:5: 10:21 error: unresolved import `std::any::TypeId`. There is no `TypeId` in `std::any`
/Users/byron/.cargo/git/checkouts/current-4c0469929c5bbcc9/master/src/lib.rs:10 use std::any::TypeId;
                                                                                    ^~~~~~~~~~~~~~~~
error: aborting due to previous error
   Compiling clock_ticks v0.0.2 (https://github.com/tomaka/clock_ticks#75347002)
   Compiling pkg-config v0.1.5
   Compiling read_color v0.0.2 (https://github.com/PistonDevelopers/read_color#568723fb)
   Compiling gcc v0.1.5
   Compiling vecmath v0.0.2 (https://github.com/PistonDevelopers/vecmath#5ac4d2ec)
   Compiling regex v0.1.10
   Compiling quack v0.0.2 (https://github.com/PistonDevelopers/quack#e12ef316)
/Users/byron/.cargo/git/checkouts/quack-5c2e81a611f5edcd/master/src/lib.rs:20:9: 20:10 error: unexpected token: `<`
/Users/byron/.cargo/git/checkouts/quack-5c2e81a611f5edcd/master/src/lib.rs:20         <(U, T) as GetFrom>::get_from(obj.borrow().deref())
                                                                                      ^
   Compiling bitflags v0.1.0
   Compiling interpolation v0.0.1 (https://github.com/PistonDevelopers/interpolation#81b572b9)
Build failed, waiting for other jobs to finish...
Could not compile `current`.
```
